### PR TITLE
Hello route

### DIFF
--- a/Sources/App/Application+build.swift
+++ b/Sources/App/Application+build.swift
@@ -46,9 +46,9 @@ func buildRouter() -> Router<AppRequestContext> {
         // logging middleware
         LogRequestsMiddleware(.info)
     }
-    // Add health endpoint
-    router.get("/health") { _,_ -> HTTPResponse.Status in
-        return .ok
+    // Add default endpoint
+    router.get("/") { _,_ in
+        return "Hello!"
     }
     return router
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -16,8 +16,8 @@ final class AppTests: XCTestCase {
         let args = TestArguments()
         let app = try await buildApplication(args)
         try await app.test(.router) { client in
-            try await client.execute(uri: "/health", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+            try await client.execute(uri: "/", method: .get) { response in
+                XCTAssertEqual(response.body, ByteBuffer(string: "Hello!"))
             }
         }
     }

--- a/configure.sh
+++ b/configure.sh
@@ -147,3 +147,5 @@ Hummingbird server framework project
 EOF
 
 popd
+
+echo "Enter the folder created and run 'swift run' to build and run your server. Then open 'localhost:8080' on your web browser."


### PR DESCRIPTION
Change `health` route to a default route that outputs "Hello!", just so users can see output from the server in their web browser.

Also add a small amount of help text at the end.