### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:6.0-noble as build
+FROM swift:6.0-noble AS build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
Tiny change:

When docker builds this build file, a small warning is thrown because `FROM` and `as` don't use the same case:

`FromAsCasing: 'as' and 'FROM' keywords' casing do not match`

<img width="768" alt="Screenshot 2025-02-11 at 16 05 54" src="https://github.com/user-attachments/assets/d35a9032-ac04-41c2-abe3-bb35f2ed8dc6" />

This PR fixes this.