### PR TITLE
Run configure.sh straight from download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
 
 Template for Hummingbird App
 
-Either click on `Use this template` or run the following to clone locally.
-```bash
-curl -L https://raw.githubusercontent.com/hummingbird-project/template/main/scripts/download.sh | bash -s <project-name> 
-```
+Run the download script and follow the instructions. 
 
-Then enter the folder created, run `./configure.sh` and follow the instructions.
+```bash
+curl -L https://raw.githubusercontent.com/hummingbird-project/template/main/scripts/download.sh | bash
+```
 
 ## Alternative method
 

--- a/configure.sh
+++ b/configure.sh
@@ -30,7 +30,7 @@ download_mo()
 
 read_input_with_default () {
     echo -n "[$1] > "
-    read -r READ_INPUT_RETURN
+    read -r READ_INPUT_RETURN </dev/tty
 
     if [ -z "$READ_INPUT_RETURN" ]; then
         READ_INPUT_RETURN="$1"
@@ -48,7 +48,7 @@ yn_prompt () {
 read_yes_no () {
     while [[ true ]]; do
         echo -n "[$(yn_prompt $1)] > "
-        read -r READ_INPUT_RETURN
+        read -r READ_INPUT_RETURN </dev/tty
 
         case "$READ_INPUT_RETURN" in
             "y" | "Y")

--- a/configure.sh
+++ b/configure.sh
@@ -139,7 +139,7 @@ mkdir -p "$TARGET_FOLDER"/.github/workflows
 
 # get base folder of target folder so we can use that as default app name
 BASE_FOLDER=$(basename "$TARGET_FOLDER")
-CLEAN_BASE_FOLDER=$(echo "$BASE_FOLDER" | sed -e 's/[^a-zA-Z0-9_]/_/g')
+CLEAN_BASE_FOLDER=$(echo "$BASE_FOLDER" | sed -e 's/[^a-zA-Z0-9_\-]/_/g')
 
 echo ""
 echo -n "Enter your Swift package name: "

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-FOLDER=${1:-}
 TEMPLATE_VERSION=2.0.4
+TEMP_DIR=$(mktemp -d)
 
-if [[ -z "$FOLDER" ]]; then
-  echo "Missing folder name"
-  echo "Usage: download.sh <folder>"
-  exit 1
-fi
+trap cleanup EXIT $?
 
-curl -sSL https://github.com/hummingbird-project/template/archive/refs/tags/"$TEMPLATE_VERSION".tar.gz | tar xvz -s /template-"$TEMPLATE_VERSION"/"$FOLDER"/
+cleanup()
+{
+    if [ -n "$TEMP_DIR" ]; then
+        rm -rf $TEMP_DIR
+    fi
+}
+
+# Run curl and extract to temp folder
+curl -sSL https://github.com/hummingbird-project/template/archive/refs/tags/"$TEMPLATE_VERSION".tar.gz | tar xvz -C $TEMP_DIR
+# Run configure.sh
+"$TEMP_DIR"/template-"$TEMPLATE_VERSION"/configure.sh


### PR DESCRIPTION
Also don't require a folder argument, instead ask in configure script.

Previously user would run download script and be required to add their folder onto the end of the cut and paste code. This would download template into that folder. The user would then ender the folder using `cd` and run `configure.sh`.

With these changes the user runs the download script without any additional arguments. It gets downloaded to a temporary folder, then configure is run from that temporary folder and an additional question is asked to set the target folder.
