### PR TITLE
fix: Use /dev/tty instead of stdin for prompts

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -30,7 +30,7 @@ download_mo()
 
 read_input_with_default () {
     echo -n "[$1] > "
-    read -r READ_INPUT_RETURN
+    read -r READ_INPUT_RETURN </dev/tty
 
     if [ -z "$READ_INPUT_RETURN" ]; then
         READ_INPUT_RETURN="$1"
@@ -48,7 +48,7 @@ yn_prompt () {
 read_yes_no () {
     while [[ true ]]; do
         echo -n "[$(yn_prompt $1)] > "
-        read -r READ_INPUT_RETURN
+        read -r READ_INPUT_RETURN </dev/tty
 
         case "$READ_INPUT_RETURN" in
             "y" | "Y")


### PR DESCRIPTION
Fixes prompting when originating script is piped to bash.

Tested to work on both Mac and Ubuntu 24.04 (main doesn't work on Ubuntu 24.04 because tar -s doesn't do the same thing).