### PR TITLE
Add basic ErrorMiddleware

### DIFF
--- a/Sources/App/Application+build.swift
+++ b/Sources/App/Application+build.swift
@@ -46,8 +46,13 @@ func buildRouter() throws -> Router<AppRequestContext> {
     let router = Router(context: AppRequestContext.self)
     // Add middleware
     router.addMiddleware {
-        // logging middleware
+        // Logging middleware
         LogRequestsMiddleware(.info)
+
+        // Error middleware, transforms internal errors into
+        // HTTP 500 responses
+        ErrorMiddleware()
+
 {{#HB_OPENAPI}}
         // store request context in TaskLocal
         OpenAPIRequestContextMiddleware()

--- a/Sources/App/ErrorMiddleware.swift
+++ b/Sources/App/ErrorMiddleware.swift
@@ -1,0 +1,22 @@
+import Hummingbird
+
+/// A middleware that handles errors.
+/// By being generic over any RequestContext, this middleware can be used regardless of
+/// the type of RequestContext.
+/// This is a simple example, and translates unknown errors into a 500 error. You might prefer
+/// to change the message to include the error description only when in DEBUG.
+struct ErrorMiddleware<Context: RequestContext>: RouterMiddleware {
+    func handle(
+        _ input: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        do {
+            return try await next(input, context)
+        } catch let error as HTTPError {
+            throw error
+        } catch {
+            throw HTTPError(.internalServerError, message: "Error: \(error)")
+        }
+    }
+}

--- a/Sources/App/OpenAPIRequestContextMiddleware.swift
+++ b/Sources/App/OpenAPIRequestContextMiddleware.swift
@@ -12,7 +12,11 @@ extension AppRequestContext {
 struct OpenAPIRequestContextMiddleware: RouterMiddleware {
     typealias Context = AppRequestContext
 
-    func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
+    func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
         try await AppRequestContext.$current.withValue(context) {
             try await next(request, context)
         }


### PR DESCRIPTION
I noticed that any error which is not an `HTTPError` makes it hard to debug, and doesn't help much in development.

I thought it can be not only useful to add an error middleware for this reason, but also to show developers how they can create their own middleware. I took the implementation from [this error middleware](https://github.com/hummingbird-project/hummingbird-examples/blob/4717adde6988d14fe0b698d9674d3f16c0a0bbd0/todos-lambda/Sources/App/lambda.swift#L97-L110).