### PR TITLE
Add support for creating lambda functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@
 /*.xcodeproj
 xcuserdata/
 /.vscode/*
-{{#HB_VSCODE_SNIPPETS}}
+{{#hbVSCodeSnippets}}
 !/.vscode/hummingbird.code-snippets
-{{/HB_VSCODE_SNIPPETS}}
+{{/hbVSCodeSnippets}}
 .env.*
 .env

--- a/.vscode/hummingbird.code-snippets
+++ b/.vscode/hummingbird.code-snippets
@@ -1,4 +1,4 @@
-{{#HB_VSCODE_SNIPPETS}}
+{{#hbVSCodeSnippets}}
 {
     "Endpoint": {
         "prefix": "endpoint",
@@ -42,4 +42,4 @@
         "description": "Hummingbird: Decode request"
     }
 }
-{{/HB_VSCODE_SNIPPETS}}
+{{/hbVSCodeSnippets}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY . .
 
 # Build the application, with optimizations, with static linking, and using jemalloc
 RUN swift build -c release \
-    --product "{{HB_EXECUTABLE_NAME}}" \
+    --product "{{hbExecutableName}}" \
     --static-swift-stdlib \
     -Xlinker -ljemalloc
 
@@ -33,7 +33,7 @@ RUN swift build -c release \
 WORKDIR /staging
 
 # Copy main executable to staging area
-RUN cp "$(swift build --package-path /build -c release --show-bin-path)/{{HB_EXECUTABLE_NAME}}" ./
+RUN cp "$(swift build --package-path /build -c release --show-bin-path)/{{hbExecutableName}}" ./
 
 # Copy static swift backtracer binary to staging area
 RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
@@ -83,5 +83,5 @@ USER hummingbird:hummingbird
 EXPOSE 8080
 
 # Start the Hummingbird service when the image is run, default to listening on 8080 in production environment
-ENTRYPOINT ["./{{HB_EXECUTABLE_NAME}}"]
+ENTRYPOINT ["./{{hbExecutableName}}"]
 CMD ["--hostname", "0.0.0.0", "--port", "8080"]

--- a/Package.swift
+++ b/Package.swift
@@ -4,47 +4,63 @@
 import PackageDescription
 
 let package = Package(
-    name: "{{HB_PACKAGE_NAME}}",
+    name: "{{hbPackageName}}",
+{{^hbLambda}}
     platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
+{{/hbLambda}}
+{{#hbLambda}}
+    platforms: [.macOS(.v15)],
+{{/hbLambda}}
     products: [
-        .executable(name: "{{HB_EXECUTABLE_NAME}}", targets: ["{{HB_EXECUTABLE_NAME}}"]),
+        .executable(name: "{{hbExecutableName}}", targets: ["{{hbExecutableName}}"]),
     ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+{{#hbLambda}}
+        .package(url: "https://github.com/hummingbird-project/hummingbird-lambda.git", from: "2.0.0"),
+{{/hbLambda}}
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.7.0"),
-        .package(url: "https://github.com/swift-server/swift-openapi-hummingbird.git", from: "2.0.1"),
-{{/HB_OPENAPI}}
+        .package(url: "https://github.com/hummingbird-project/swift-openapi-hummingbird.git", from: "2.0.1"),
+{{/hbOpenAPI}}
     ],
     targets: [
-        .executableTarget(name: "{{HB_EXECUTABLE_NAME}}",
+        .executableTarget(name: "{{hbExecutableName}}",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Hummingbird", package: "hummingbird"),
-{{#HB_OPENAPI}}
-                .byName(name: "{{HB_EXECUTABLE_NAME}}API"),
+{{#hbLambda}}
+                .product(name: "HummingbirdLambda", package: "hummingbird-lambda"),
+{{/hbLambda}}
+{{#hbOpenAPI}}
+                .byName(name: "{{hbExecutableName}}API"),
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
                 .product(name: "OpenAPIHummingbird", package: "swift-openapi-hummingbird"),
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}
             ],
             path: "Sources/App"
         ),
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
         .target(
-            name: "{{HB_EXECUTABLE_NAME}}API",
+            name: "{{hbExecutableName}}API",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime")
             ],
             path: "Sources/AppAPI",
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
         ),
-{{/HB_OPENAPI}}
-        .testTarget(name: "{{HB_EXECUTABLE_NAME}}Tests",
+{{/hbOpenAPI}}
+        .testTarget(name: "{{hbExecutableName}}Tests",
             dependencies: [
-                .byName(name: "{{HB_EXECUTABLE_NAME}}"),
+                .byName(name: "{{hbExecutableName}}"),
+{{^hbLambda}}
                 .product(name: "HummingbirdTesting", package: "hummingbird")
+{{/hbLambda}}
+{{#hbLambda}}
+                .product(name: "HummingbirdLambdaTesting", package: "hummingbird-lambda"),
+{{/hbLambda}}
             ],
             path: "Tests/AppTests"
         )

--- a/Sources/App/APIImplementation.swift
+++ b/Sources/App/APIImplementation.swift
@@ -1,4 +1,4 @@
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
 import AppAPI
 import OpenAPIRuntime
 
@@ -7,4 +7,4 @@ struct APIImplementation: APIProtocol {
         return .ok(.init(body: .plainText("Hello!")))
     }
 }
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}

--- a/Sources/App/App+build.swift
+++ b/Sources/App/App+build.swift
@@ -1,44 +1,69 @@
+{{#hbLambda}}
+import AWSLambdaEvents
+{{/hbLambda}}
 import Hummingbird
+{{#hbLambda}}
+import HummingbirdLambda
+{{/hbLambda}}
 import Logging
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
 import OpenAPIHummingbird
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}
 
+{{^hbLambda}}
 /// Application arguments protocol. We use a protocol so we can call
 /// `buildApplication` inside Tests as well as in the App executable. 
 /// Any variables added here also have to be added to `App` in App.swift and 
 /// `TestArguments` in AppTest.swift
-public protocol AppArguments {
+package protocol AppArguments {
     var hostname: String { get }
     var port: Int { get }
     var logLevel: Logger.Level? { get }
 }
+{{/hbLambda}}
 
-// Request context used by application
-typealias AppRequestContext = BasicRequestContext
+// Request context used by {{^hbLambda}}application{{/hbLambda}}{{#hbLambda}}lambda<APIGatewayV2Request>{{/hbLambda}}
+typealias AppRequestContext = {{^hbLambda}}BasicRequestContext{{/hbLambda}}{{#hbLambda}}BasicLambdaRequestContext<APIGatewayV2Request>{{/hbLambda}}
 
+{{^hbLambda}}
 ///  Build application
 /// - Parameter arguments: application arguments
-public func buildApplication(_ arguments: some AppArguments) async throws -> some ApplicationProtocol {
+func buildApplication(_ arguments: some AppArguments) async throws -> some ApplicationProtocol {
+{{/hbLambda}}
+{{#hbLambda}}
+///  Build AWS Lambda function
+func buildLambda() async throws -> APIGatewayV2LambdaFunction<RouterResponder<AppRequestContext>> {
+{{/hbLambda}}
     let environment = Environment()
     let logger = {
-        var logger = Logger(label: "{{HB_PACKAGE_NAME}}")
+        var logger = Logger(label: "{{hbPackageName}}")
         logger.logLevel = 
+{{^hbLambda}}
             arguments.logLevel ??
+{{/hbLambda}}
             environment.get("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ??
             .info
         return logger
     }()
     let router = try buildRouter()
+{{^hbLambda}}
     let app = Application(
         router: router,
         configuration: .init(
             address: .hostname(arguments.hostname, port: arguments.port),
-            serverName: "{{HB_PACKAGE_NAME}}"
+            serverName: "{{hbPackageName}}"
         ),
         logger: logger
     )
     return app
+{{/hbLambda}}
+{{#hbLambda}}
+    let lambda = APIGatewayV2LambdaFunction(
+        router: router,
+        logger: logger
+    )
+    return lambda
+{{/hbLambda}}
 }
 
 /// Build router
@@ -48,21 +73,21 @@ func buildRouter() throws -> Router<AppRequestContext> {
     router.addMiddleware {
         // logging middleware
         LogRequestsMiddleware(.info)
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
         // store request context in TaskLocal
         OpenAPIRequestContextMiddleware()
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}
     }
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
     // Add OpenAPI handlers
     let api = APIImplementation()
     try api.registerHandlers(on: router)
-{{/HB_OPENAPI}}
-{{^HB_OPENAPI}}
+{{/hbOpenAPI}}
+{{^hbOpenAPI}}
     // Add default endpoint
     router.get("/") { _,_ in
         return "Hello!"
     }
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}
     return router
 }

--- a/Sources/App/App+build.swift
+++ b/Sources/App/App+build.swift
@@ -22,8 +22,8 @@ package protocol AppArguments {
 }
 {{/hbLambda}}
 
-// Request context used by {{^hbLambda}}application{{/hbLambda}}{{#hbLambda}}lambda<APIGatewayV2Request>{{/hbLambda}}
-typealias AppRequestContext = {{^hbLambda}}BasicRequestContext{{/hbLambda}}{{#hbLambda}}BasicLambdaRequestContext<APIGatewayV2Request>{{/hbLambda}}
+// Request context used by {{^hbLambda}}application{{/hbLambda}}{{#hbLambda}}lambda<{{hbLambdaType}}Request>{{/hbLambda}}
+typealias AppRequestContext = {{^hbLambda}}BasicRequestContext{{/hbLambda}}{{#hbLambda}}BasicLambdaRequestContext<{{hbLambdaType}}Request>{{/hbLambda}}
 
 {{^hbLambda}}
 ///  Build application
@@ -32,7 +32,7 @@ func buildApplication(_ arguments: some AppArguments) async throws -> some Appli
 {{/hbLambda}}
 {{#hbLambda}}
 ///  Build AWS Lambda function
-func buildLambda() async throws -> APIGatewayV2LambdaFunction<RouterResponder<AppRequestContext>> {
+func buildLambda() async throws -> {{hbLambdaType}}LambdaFunction<RouterResponder<AppRequestContext>> {
 {{/hbLambda}}
     let environment = Environment()
     let logger = {
@@ -58,7 +58,7 @@ func buildLambda() async throws -> APIGatewayV2LambdaFunction<RouterResponder<Ap
     return app
 {{/hbLambda}}
 {{#hbLambda}}
-    let lambda = APIGatewayV2LambdaFunction(
+    let lambda = {{hbLambdaType}}LambdaFunction(
         router: router,
         logger: logger
     )

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Hummingbird
 import Logging
 
+{{^hbLambda}}
 @main
 struct AppCommand: AsyncParsableCommand, AppArguments {
     @Option(name: .shortAndLong)
@@ -25,3 +26,13 @@ struct AppCommand: AsyncParsableCommand, AppArguments {
 #else
     extension Logger.Level: ExpressibleByArgument {}
 #endif
+{{/hbLambda}}
+{{#hbLambda}}
+@main
+struct Lambda {
+    static func main() async throws {
+        let lambda = try await buildLambda()
+        try await lambda.runService()
+    }
+}
+{{^hbLambda}}

--- a/Sources/App/OpenAPIRequestContextMiddleware.swift
+++ b/Sources/App/OpenAPIRequestContextMiddleware.swift
@@ -1,4 +1,4 @@
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
 import Hummingbird
 
 extension AppRequestContext {
@@ -18,4 +18,4 @@ struct OpenAPIRequestContextMiddleware: RouterMiddleware {
         }
     }
 }
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}

--- a/Sources/AppAPI/AppAPI.swift
+++ b/Sources/AppAPI/AppAPI.swift
@@ -1,3 +1,3 @@
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
 // Empty swift file, needed for SwiftPM to recognize this is a Swift target
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}

--- a/Sources/AppAPI/openapi-generator-config.yaml
+++ b/Sources/AppAPI/openapi-generator-config.yaml
@@ -1,7 +1,7 @@
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
 generate:
   - types
   - server
 accessModifier: package
 namingStrategy: idiomatic
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}

--- a/Sources/AppAPI/openapi.yaml
+++ b/Sources/AppAPI/openapi.yaml
@@ -1,4 +1,4 @@
-{{#HB_OPENAPI}}
+{{#hbOpenAPI}}
 openapi: '3.1.0'
 info:
   title: AppService
@@ -17,4 +17,4 @@ paths:
             text/plain:
               schema:
                 type: string
-{{/HB_OPENAPI}}
+{{/hbOpenAPI}}

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -1,17 +1,25 @@
 import Hummingbird
+{{^hbLambda}}
 import HummingbirdTesting
+{{/hbLambda}}
+{{#hbLambda}}
+import HummingbirdLambdaTesting
+{{/hbLambda}}
 import Logging
 import XCTest
 
-@testable import {{HB_EXECUTABLE_NAME}}
+@testable import {{hbExecutableName}}
 
 final class AppTests: XCTestCase {
+{{^hbLambda}}
     struct TestArguments: AppArguments {
         let hostname = "127.0.0.1"
         let port = 0
         let logLevel: Logger.Level? = .trace
     }
+{{/hbLambda}}
 
+{{^hbLambda}}
     func testApp() async throws {
         let args = TestArguments()
         let app = try await buildApplication(args)
@@ -21,4 +29,15 @@ final class AppTests: XCTestCase {
             }
         }
     }
+{{/hbLambda}}
+{{#hbLambda}}
+    func testLambda() async throws {
+        let lambda = try await buildLambda()
+        try await lambda.test() { client in
+            try await client.execute(uri: "/", method: .get) { response in
+                XCTAssertEqual(response.body, "Hello!")
+            }
+        }
+    }
+{{/hbLambda}}
 }

--- a/configure.sh
+++ b/configure.sh
@@ -101,8 +101,8 @@ exitWithError()
 }
 
 check_valid() {
-    if [[ "$HB_PACKAGE_NAME" =~ [^a-zA-Z0-9_] ]]; then
-        exitWithError "Invalid package name: $HB_PACKAGE_NAME"
+    if [[ "$hbPackageName" =~ [^a-zA-Z0-9_] ]]; then
+        exitWithError "Invalid package name: $hbPackageName"
     fi
 }
 trap cleanup EXIT $?
@@ -146,29 +146,36 @@ CLEAN_BASE_FOLDER=$(echo "$BASE_FOLDER" | sed -e 's/[^a-zA-Z0-9_\-]/_/g')
 echo ""
 echo -n "Enter your Swift package name: "
 read_input_with_default "$CLEAN_BASE_FOLDER"
-export HB_PACKAGE_NAME=$READ_INPUT_RETURN
-if [[ "$HB_PACKAGE_NAME" =~ [^a-zA-Z0-9_-] ]]; then
-    exitWithError "Invalid package name: $HB_PACKAGE_NAME"
+export hbPackageName=$READ_INPUT_RETURN
+if [[ "$hbPackageName" =~ [^a-zA-Z0-9_-] ]]; then
+    exitWithError "Invalid package name: $hbPackageName"
 fi
 
-echo -n "Enter your executable name: "
-read_input_with_default "App"
-export HB_EXECUTABLE_NAME=$READ_INPUT_RETURN
-if [[ "$HB_EXECUTABLE_NAME" =~ [^a-zA-Z0-9_] ]]; then
-    exitWithError "Invalid executable name: $HB_EXECUTABLE_NAME"
-fi
-
-echo -n "Do you want to use the OpenAPI generator: "
+echo -n "Do you want to build an AWS Lambda function? "
 read_yes_no "no"
 if [[ "$READ_INPUT_RETURN" == "yes" ]]; then
-    export HB_OPENAPI="yes"
+    export hbLambda="yes"
+    export hbExecutableName="App"
+else
+    echo -n "Enter your executable name: "
+    read_input_with_default "App"
+    export hbExecutableName=$READ_INPUT_RETURN
+    if [[ "$hbExecutableName" =~ [^a-zA-Z0-9_] ]]; then
+        exitWithError "Invalid executable name: $hbExecutableName"
+    fi
+fi
+
+echo -n "Do you want to use the OpenAPI generator? "
+read_yes_no "no"
+if [[ "$READ_INPUT_RETURN" == "yes" ]]; then
+    export hbOpenAPI="yes"
     mkdir -p "$TARGET_FOLDER"/Sources/AppAPI
 fi
 
 echo -n "Include Visual Studio Code snippets: "
 read_yes_no "no"
 if [[ "$READ_INPUT_RETURN" == "yes" ]]; then
-    export HB_VSCODE_SNIPPETS="yes"
+    export hbVSCodeSnippets="yes"
 fi
 
 echo ""
@@ -184,7 +191,7 @@ run_mustache "$FILES" "$TARGET_FOLDER"
 
 # README file
 cat <<EOF | $MO > "$TARGET_FOLDER"/README.md
-# $HB_PACKAGE_NAME
+# $hbPackageName
 Hummingbird server framework project
 EOF
 

--- a/configure.sh
+++ b/configure.sh
@@ -155,6 +155,7 @@ echo -n "Do you want to build an AWS Lambda function? "
 read_yes_no "no"
 if [[ "$READ_INPUT_RETURN" == "yes" ]]; then
     export hbLambda="yes"
+    export hbLambdaType="APIGatewayV2"
     export hbExecutableName="App"
 else
     echo -n "Enter your executable name: "


### PR DESCRIPTION
- Adds support for creating AWS Lambda functions. Can create APIGateway, APIGateway2 and FunctionURL lambdas but configure script currently defaults to APIGateway2
- Renamed all the environment variables to camel case
- Renamed application+build.swift to App+build.swift