### PR TITLE
Fixed build error by making log level conform to ExpressibleByArgument

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.8.0"),
 {{#hbLambda}}
         .package(url: "https://github.com/hummingbird-project/hummingbird-lambda.git", from: "2.0.0"),
 {{/hbLambda}}
@@ -29,6 +30,7 @@ let package = Package(
     targets: [
         .executableTarget(name: "{{hbExecutableName}}",
             dependencies: [
+                .product(name: "Logging", package: "swift-log"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Hummingbird", package: "hummingbird"),
 {{#hbLambda}}

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -22,9 +22,17 @@ struct AppCommand: AsyncParsableCommand, AppArguments {
 
 /// Extend `Logger.Level` so it can be used as an argument
 #if hasFeature(RetroactiveAttribute)
-    extension Logger.Level: @retroactive ExpressibleByArgument {}
+    extension Logger.Level: @retroactive ExpressibleByArgument {
+        public init?(argument: String) {
+            self.init(rawValue: argument)
+        }
+    }
 #else
-    extension Logger.Level: ExpressibleByArgument {}
+    extension Logger.Level: ExpressibleByArgument {
+        public init?(argument: String) {
+            self.init(rawValue: argument)
+        }
+    }
 #endif
 {{/hbLambda}}
 {{#hbLambda}}


### PR DESCRIPTION
With the release of swift-log 1.8.0, `Logger.Level` no longer directly conforms to `ExpressibleByArgument` (see: https://github.com/apple/swift-log/pull/395). This causes a build error when using this template to create a new project.

To make it conform to this, we can simply add the required initializer in the extension and use the raw value of the string as the argument name.

For the time being, I've added swift-log as a dependency in the `Package.swift` file to specify 1.8.0 as the minimum required version to prove the solution works; it's not actually required and can be removed when merging.