### PR TITLE
Replace Argument Parser with Swift Configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "{{hbPackageName}}",
 {{^hbLambda}}
-    platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
+    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18)],
 {{/hbLambda}}
 {{#hbLambda}}
     platforms: [.macOS(.v15)],
@@ -19,7 +19,7 @@ let package = Package(
 {{#hbLambda}}
         .package(url: "https://github.com/hummingbird-project/hummingbird-lambda.git", from: "2.0.0"),
 {{/hbLambda}}
-        .package(url: "github.com/apple/swift-configuration", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.0.0", traits: [.defaults, "CommandLineArguments"]),
 {{#hbOpenAPI}}
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.7.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
 {{#hbLambda}}
         .package(url: "https://github.com/hummingbird-project/hummingbird-lambda.git", from: "2.0.0"),
 {{/hbLambda}}
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
+        .package(url: "github.com/apple/swift-configuration", from: "1.0.0"),
 {{#hbOpenAPI}}
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.7.0"),
@@ -29,7 +29,7 @@ let package = Package(
     targets: [
         .executableTarget(name: "{{hbExecutableName}}",
             dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Configuration", package: "swift-configuration"),
                 .product(name: "Hummingbird", package: "hummingbird"),
 {{#hbLambda}}
                 .product(name: "HummingbirdLambda", package: "hummingbird-lambda"),

--- a/Sources/App/App+build.swift
+++ b/Sources/App/App+build.swift
@@ -16,29 +16,24 @@ typealias AppRequestContext = {{^hbLambda}}BasicRequestContext{{/hbLambda}}{{#hb
 
 {{^hbLambda}}
 ///  Build application
-/// - Parameter configReader: configuration reader
-func buildApplication(configReader: ConfigReader) async throws -> some ApplicationProtocol {
+/// - Parameter reader: configuration reader
+func buildApplication(reader: ConfigReader) async throws -> some ApplicationProtocol {
 {{/hbLambda}}
 {{#hbLambda}}
 ///  Build AWS Lambda function
-func buildLambda() async throws -> {{hbLambdaType}}LambdaFunction<RouterResponder<AppRequestContext>> {
+/// - Parameter reader: configuration reader
+func buildLambda(reader: ConfigReader) async throws -> {{hbLambdaType}}LambdaFunction<RouterResponder<AppRequestContext>> {
 {{/hbLambda}}
     let logger = {
         var logger = Logger(label: "{{hbPackageName}}")
-        logger.logLevel = configReader.string(forKey: "log.level", as: Logger.Level.self, default: .info)
+        logger.logLevel = reader.string(forKey: "log.level", as: Logger.Level.self, default: .info)
         return logger
     }()
     let router = try buildRouter()
 {{^hbLambda}}
     let app = Application(
         router: router,
-        configuration: .init(
-            address: .hostname(
-                configReader.string(forKey: "host", default: "127.0.0.1"),
-                port: configReader.int(forKey: "port", default: 8080)
-            ),
-            serverName: "{{hbPackageName}}"
-        ),
+        configuration: ApplicationConfiguration(reader: reader),
         logger: logger
     )
     return app

--- a/Sources/App/App+build.swift
+++ b/Sources/App/App+build.swift
@@ -33,7 +33,7 @@ func buildLambda(reader: ConfigReader) async throws -> {{hbLambdaType}}LambdaFun
 {{^hbLambda}}
     let app = Application(
         router: router,
-        configuration: ApplicationConfiguration(reader: reader),
+        configuration: ApplicationConfiguration(reader: reader.scoped(to: "http")),
         logger: logger
     )
     return app

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -9,7 +9,7 @@ struct App {
         let reader = ConfigReader(providers: [
             CommandLineArgumentsProvider(),
             EnvironmentVariablesProvider(),
-            InMemoryProvider([
+            InMemoryProvider(values: [
                 "server.name": "{{hbPackageName}}"
             ])
         ])

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -6,11 +6,14 @@ import Logging
 @main
 struct App {
     static func main() async throws {
-        let reader = ConfigReader(providers: [
+        // Application will read configuration from the following in the order listed
+        // Command line, Environment variables, dotEnv file, defaults provided in memory 
+        let reader = try await ConfigReader(providers: [
             CommandLineArgumentsProvider(),
             EnvironmentVariablesProvider(),
+            EnvironmentVariablesProvider(environmentFilePath: ".env", allowMissing: true),
             InMemoryProvider(values: [
-                "server.name": "{{hbPackageName}}"
+                "http.serverName": "{{hbPackageName}}"
             ])
         ])
         let app = try await buildApplication(reader: reader)

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -3,37 +3,17 @@ import Hummingbird
 import Logging
 
 {{^hbLambda}}
-/// The main entry point of the application.
-///
-/// Configuration can be provided via command-line arguments or environment variables.
-/// Command-line arguments take precedence over environment variables.
-///
-/// ## Supported configuration
-///
-/// - `--host` / `HTTP_HOST`: Hostname or IP to bind to (default: `127.0.0.1`)
-/// - `--port` / `HTTP_PORT`: Port number to listen on (default: `8080`)
-/// - `--log-level` / `LOG_LEVEL`: Logging level - See `Logger.Level` for the possible values (default: `info`)
-///
-/// ## Examples
-///
-/// Using command-line arguments:
-/// ```bash
-/// swift run {{hbExecutableName}} --host 0.0.0.0 --port 3000 --log-level debug
-/// ```
-///
-/// Using environment variables:
-/// ```bash
-/// HTTP_HOST=0.0.0.0 HTTP_PORT=3000 LOG_LEVEL=debug swift run {{hbExecutableName}}
-/// ```
 @main
 struct App {
     static func main() async throws {
-        let configReader = ConfigReader(providers: [
+        let reader = ConfigReader(providers: [
             CommandLineArgumentsProvider(),
-            EnvironmentVariablesProvider().prefixKeys(with: "http"),
-            EnvironmentVariablesProvider()
+            EnvironmentVariablesProvider(),
+            InMemoryProvider([
+                "server.name": "{{hbPackageName}}"
+            ])
         ])
-        let app = try await buildApplication(configReader: configReader)
+        let app = try await buildApplication(reader: reader)
         try await app.runService()
     }
 }
@@ -42,7 +22,10 @@ struct App {
 @main
 struct Lambda {
     static func main() async throws {
-        let lambda = try await buildLambda()
+        let reader = ConfigReader(providers: [
+            EnvironmentVariablesProvider()
+        ])
+        let lambda = try await buildLambda(reader: reader)
         try await lambda.runService()
     }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -7,39 +7,47 @@ import HummingbirdTesting
 import HummingbirdLambdaTesting
 {{/hbLambda}}
 import Logging
-import XCTest
+import Testing
 
 @testable import {{hbExecutableName}}
 
-final class AppTests: XCTestCase {
 {{^hbLambda}}
-    func testApp() async throws {
-        let reader = ConfigReader(providers: [
-            InMemoryProvider(name: nil, values: [
-                "host": "127.0.0.1",
-                "port": "0",
-                "log.level": "trace"
-            ])
-        ])
+private let reader = ConfigReader(providers: [
+    InMemoryProvider(values: [
+        "host": "127.0.0.1",
+        "port": "0",
+        "log.level": "trace"
+    ])
+])
+{{/hbLambda}}
+{{#hbLambda}}
+private let reader = ConfigReader(providers: [
+    InMemoryProvider(values: [
+        "log.level": "trace"
+    ])
+])
+{{/hbLambda}}
+
+@Suite
+struct AppTests {
+{{^hbLambda}}
+    @Test
+    func app() async throws {
         let app = try await buildApplication(reader: reader)
         try await app.test(.router) { client in
             try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.body, ByteBuffer(string: "Hello!"))
+                #expect(response.body == ByteBuffer(string: "Hello!"))
             }
         }
     }
 {{/hbLambda}}
 {{#hbLambda}}
-    func testLambda() async throws {
-        let reader = ConfigReader(providers: [
-            InMemoryProvider([
-                "log.level": "trace"
-            ])
-        ])
+    @Test
+    func lambda() async throws {
         let lambda = try await buildLambda(reader: reader)
         try await lambda.test() { client in
             try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.body, "Hello!")
+                #expect(response.body == "Hello!")
             }
         }
     }

--- a/configure.sh
+++ b/configure.sh
@@ -158,6 +158,7 @@ if [[ "$READ_INPUT_RETURN" == "yes" ]]; then
     export hbLambdaType="APIGatewayV2"
     export hbExecutableName="App"
 else
+    export hbLambda=""
     echo -n "Enter your executable name: "
     read_input_with_default "App"
     export hbExecutableName=$READ_INPUT_RETURN
@@ -171,12 +172,16 @@ read_yes_no "no"
 if [[ "$READ_INPUT_RETURN" == "yes" ]]; then
     export hbOpenAPI="yes"
     mkdir -p "$TARGET_FOLDER"/Sources/AppAPI
+else
+    export hbOpenAPI=""
 fi
 
 echo -n "Include Visual Studio Code snippets: "
 read_yes_no "no"
 if [[ "$READ_INPUT_RETURN" == "yes" ]]; then
     export hbVSCodeSnippets="yes"
+else
+    export hbVSCodeSnippets=""
 fi
 
 echo ""
@@ -184,7 +189,7 @@ echo ""
 pushd $TEMPLATE_FOLDER > /dev/null
 
 # Root level files
-FILES=$(find . -maxdepth 1 ! -type d ! -name "*.sh" ! -name LICENSE)
+FILES=$(find . -maxdepth 1 ! -type d ! -name "*.sh" ! -name LICENSE ! -name ".DS_Store")
 run_mustache "$FILES" "$TARGET_FOLDER"
 # Files in Sources and Tests folder
 FILES=$(find Sources Tests .github .vscode/hummingbird.code-snippets ! -type d)


### PR DESCRIPTION
After [this PR](https://github.com/hummingbird-project/hummingbird/pull/743) integrated swift-configuration, and v2.8 released with this, I prepared an initial usage of swift-configuration to replace the dependency on the Swift Argument Parser.

Right now, because [in this line](https://github.com/hummingbird-project/template/blob/2564827fc5838d6b73eb15ad293c40cbf441fece/Sources/App/App%2Bbuild.swift#L54) the server name is set to`{{hbPackageName}}`, I preferred to keep it as it is, and access the properties in the `ConfigReader`, instead of forwarding the "untouched" reader to the `ApplicationConfiguration.init(reader: ConfigReader)` method.