### PR TITLE
Fix OpenAPI target name

### DIFF
--- a/Sources/App/APIImplementation.swift
+++ b/Sources/App/APIImplementation.swift
@@ -1,9 +1,9 @@
 {{#hbOpenAPI}}
-import AppAPI
+import {{hbExecutableName}}API
 import OpenAPIRuntime
 
 struct APIImplementation: APIProtocol {
-    func getHello(_ input: AppAPI.Operations.GetHello.Input) async throws -> AppAPI.Operations.GetHello.Output {
+    func getHello(_ input: {{hbExecutableName}}API.Operations.GetHello.Input) async throws -> {{hbExecutableName}}API.Operations.GetHello.Output {
         return .ok(.init(body: .plainText("Hello!")))
     }
 }


### PR DESCRIPTION
Fix import of OpenAPI target in APIImplementation.swift. Previously it assumed it was called AppAPI